### PR TITLE
Fix bug #18

### DIFF
--- a/background.js
+++ b/background.js
@@ -38,6 +38,9 @@ var tabIdToSavedWindowId = new Object();
 // window-closing intention on tab removal
 var isWindowClosing = new Object();
 
+// window-loading flag. loading tabs can't effect saved state
+var istabLoading = {};
+
 
 /* INIT */
 

--- a/eventHandlers.js
+++ b/eventHandlers.js
@@ -49,6 +49,10 @@ chrome.tabs.onSelectionChanged.addListener(onTabSelectionChanged);
 
 
 function onTabUpdated(tabId, info, tab) {
+    if(info.status=='loading')
+        istabLoading[tabId]=true;
+    else
+      delete istabLoading[tabId];
   onTabChanged(tabId, tab.windowId);
 }
 chrome.tabs.onUpdated.addListener(onTabUpdated);
@@ -56,9 +60,13 @@ chrome.tabs.onUpdated.addListener(onTabUpdated);
 
 // updates a window in response to a tab event
 function onTabChanged(tabId, windowId) {
-  if (isWindowClosing[windowId])
+  if (isWindowClosing[windowId]||istabLoading[tabId])
     return;
   getPopulatedWindow(windowId, function(browserWindow) {
+    //recheck flags
+    if (isWindowClosing[windowId]||istabLoading[tabId]){
+            return;
+    }
     // if the window is saved, we update it
     if (windowIdToName[windowId]) {
       tabIdToSavedWindowId[tabId] = windowId;


### PR DESCRIPTION
Bug was due to chrome api being asynchronous.
Opening a saved window then closing it clears the state.
Added in feature that unloaded tabs can't effect saved state.
