### PR TITLE
Make sure that popup closes when a different window get focused

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -109,6 +109,8 @@ function openSavedWindow(event) {
 
   var savedWindow = backgroundPage.savedWindows[name];
   backgroundPage._gaq.push(['_trackEvent', 'popup', 'openWindow', 'Value is tab count.', savedWindow.tabs.length]);
+  
+  window.close();
 }
 
 
@@ -122,6 +124,8 @@ function focusOpenWindow(event) {
 
   chrome.windows.update(savedWindow.id, {focused: true});
   backgroundPage._gaq.push(['_trackEvent', 'popup', 'focusWindow']);
+  
+  window.close();
 }
 
 


### PR DESCRIPTION
I've found that the popup stays open when a different window gets focused.

If you'd like I can also make a short screen recording of what I mean if it's unclear.
